### PR TITLE
Fix transaction type mapping in OfxSharp

### DIFF
--- a/Lib/OfxTransactionType.cs
+++ b/Lib/OfxTransactionType.cs
@@ -4,6 +4,8 @@ namespace OfxSharpLib
 {
     public enum OfxTransactionType
     {
+        [Description("Unknown type")]
+        Unknown,
         [Description("Basic Credit")]
         CREDIT,
         [Description("Basic Debit")]

--- a/Lib/Transaction.cs
+++ b/Lib/Transaction.cs
@@ -107,13 +107,14 @@ namespace OfxSharpLib
         }
 
         /// <summary>
-        /// Returns TransactionType from string version
+        /// Returns TransactionType from string version, if not found returns Unknown some banks use different transaction types no mapped here
         /// </summary>
         /// <param name="transactionType">string version of transaction type</param>
         /// <returns>Enum version of given transaction type string</returns>
         private OfxTransactionType GetTransactionType(string transactionType)
         {
-         return (OfxTransactionType) Enum.Parse(typeof (OfxTransactionType), transactionType);
+            Enum.TryParse(transactionType, out OfxTransactionType type);
+            return type;
         }
 
         /// <summary>


### PR DESCRIPTION
- Changed so that if the transaction type is not mapped in the Enum, it returns the default Unknown, thus preventing types created by the institution from breaking the interpretation of the file. Now any type sent by banks is interpreted normally.