### PR TITLE
Updating module OFXSharp with a new method to fix SGML open tags befo…

### DIFF
--- a/Lib/OfxDocumentParser.cs
+++ b/Lib/OfxDocumentParser.cs
@@ -195,17 +195,14 @@ namespace OfxSharpLib
 
         private string FixSgmlClosingTags(string ofxContent)
         {
-            var pattern = @"<(?<tag>\w+?)>(?<content>[^<]*)";
-            var regex = new Regex(pattern);
-            var matches = regex.Matches(ofxContent);
-
+            var regex = new Regex(@"<(?<tag>\w+?)>(?<content>[^<]*)");
+            
             var fixedContent = new StringBuilder();
             int lastIndex = 0;
 
-            foreach (Match match in matches)
+            foreach (Match match in regex.Matches(ofxContent))
             {
-                fixedContent.Append(ofxContent.Substring(lastIndex, match.Index - lastIndex));
-
+                fixedContent.Append(ofxContent, lastIndex, match.Index - lastIndex);
                 var tagName = match.Groups["tag"].Value;
                 var content = match.Groups["content"].Value.Trim();
 
@@ -220,7 +217,6 @@ namespace OfxSharpLib
             }
 
             fixedContent.Append(ofxContent.Substring(lastIndex));
-
             return fixedContent.ToString();
         }
 


### PR DESCRIPTION
The SGML to XML conversion was wrongly closing the tags. It was transforming this:
<CURDEF>BRL <CCACCTFROM> <BANKID>655 <ACCTID>0001/15588636 <ACCTTYPE>CHECKING </CCACCTFROM>

into this
<CURDEF>BRL <CCACCTFROM> <BANKID>655 <ACCTID>0001/15588636 <ACCTTYPE>CHECKING </CCACCTFROM> </CURDEF>

As we use an external library for reading the Sgml files (SgmlReader), I've added a method before it for closing the open tags correctly and going through the normal conversion process.